### PR TITLE
Add browser-based AI chatbot ("digital ghost")

### DIFF
--- a/about.html
+++ b/about.html
@@ -70,4 +70,6 @@
     </div>
 
     <script src="js/theme.js"></script>
+    <script src="js/ghost-context.js"></script>
+    <script src="js/ghost-chat.js" type="module"></script>
 </body>

--- a/blog-posts/1-job-helper/job-helper-calculator.html
+++ b/blog-posts/1-job-helper/job-helper-calculator.html
@@ -369,5 +369,7 @@
 </script>
 
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/1-job-helper/job-helper.html
+++ b/blog-posts/1-job-helper/job-helper.html
@@ -153,5 +153,7 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/10-automated-blog-pipeline/automated-blog-pipeline.html
+++ b/blog-posts/10-automated-blog-pipeline/automated-blog-pipeline.html
@@ -426,6 +426,8 @@ git push origin master</code></pre>
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 
   <script>
     // Konami Code: ↑↑↓↓←→←→BA

--- a/blog-posts/11-ai-eats-cybersecurity/ai-eats-cybersecurity.html
+++ b/blog-posts/11-ai-eats-cybersecurity/ai-eats-cybersecurity.html
@@ -533,6 +533,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/12-labormaxxing-vs-knowledgemaxxing/labormaxxing-vs-knowledgemaxxing.html
+++ b/blog-posts/12-labormaxxing-vs-knowledgemaxxing/labormaxxing-vs-knowledgemaxxing.html
@@ -898,6 +898,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/13-harness-is-the-security-layer/harness-is-the-security-layer.html
+++ b/blog-posts/13-harness-is-the-security-layer/harness-is-the-security-layer.html
@@ -761,6 +761,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/14-harness-engineering/harness-engineering.html
+++ b/blog-posts/14-harness-engineering/harness-engineering.html
@@ -799,6 +799,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/15-pi-governance/pi-governance.html
+++ b/blog-posts/15-pi-governance/pi-governance.html
@@ -1191,6 +1191,8 @@ dlp:
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/2-ira-cal/ira-cal.html
+++ b/blog-posts/2-ira-cal/ira-cal.html
@@ -258,5 +258,7 @@
         }
     </script>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/3-gnostic/gnostic.html
+++ b/blog-posts/3-gnostic/gnostic.html
@@ -255,5 +255,7 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/4-diptychs-and-triptychs-auto-slicer/diptychs-and-triptychs-auto-slicer.html
+++ b/blog-posts/4-diptychs-and-triptychs-auto-slicer/diptychs-and-triptychs-auto-slicer.html
@@ -183,5 +183,7 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/5-vertical-ai/vertical-ai.html
+++ b/blog-posts/5-vertical-ai/vertical-ai.html
@@ -129,6 +129,8 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>
 

--- a/blog-posts/6-vertical-saas/vertical-saas.html
+++ b/blog-posts/6-vertical-saas/vertical-saas.html
@@ -219,6 +219,8 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>
 

--- a/blog-posts/7-workflows/workflows.html
+++ b/blog-posts/7-workflows/workflows.html
@@ -601,5 +601,7 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 </html>

--- a/blog-posts/8-ai-rollup/ai-rollup.html
+++ b/blog-posts/8-ai-rollup/ai-rollup.html
@@ -314,6 +314,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/9-large-codebase-vibes/large-codebase-vibes.html
+++ b/blog-posts/9-large-codebase-vibes/large-codebase-vibes.html
@@ -303,6 +303,8 @@
   </div>
 
   <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog-posts/template.html
+++ b/blog-posts/template.html
@@ -49,6 +49,8 @@
         </div>
     </div>
     <script src="/js/theme.js"></script>
+    <script src="/js/ghost-context.js"></script>
+    <script src="/js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/blog.html
+++ b/blog.html
@@ -175,6 +175,8 @@
 
 
     <script src="js/theme.js"></script>
+    <script src="js/ghost-context.js"></script>
+    <script src="js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -744,3 +744,332 @@ body.light-mode .legend-item {
 body.light-mode .legend-percent {
     color: #1a1a1a;
 }
+
+/* ─── Ghost Terminal Chat Widget ─────────────────────────────── */
+
+#ghost-terminal {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    font-family: 'Courier Prime', 'Courier New', monospace;
+    font-size: 14px;
+}
+
+/* ─── Bottom Bar (Collapsed State) ──────────────────────────── */
+
+#ghost-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: rgba(10, 10, 10, 0.95);
+    border-top: 1px solid #333;
+    padding: 8px 16px;
+    cursor: pointer;
+    user-select: none;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+#ghost-bar:hover {
+    background: rgba(20, 20, 20, 0.98);
+}
+
+.ghost-prompt {
+    display: flex;
+    align-items: center;
+    gap: 0;
+}
+
+.ghost-user { color: #4ec9b0; }
+.ghost-at { color: #888; }
+.ghost-host { color: #569cd6; }
+.ghost-sep { color: #888; }
+.ghost-cmd { color: #dcdcaa; }
+
+.ghost-cursor {
+    color: #c0c0c0;
+    animation: ghost-blink 1s step-end infinite;
+    font-size: 12px;
+    margin-left: 2px;
+}
+
+@keyframes ghost-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+.ghost-hint {
+    color: #666;
+    font-size: 12px;
+    flex: 1;
+    text-align: right;
+    margin-right: 12px;
+}
+
+#ghost-expand-btn {
+    background: none;
+    border: none;
+    color: #888;
+    cursor: pointer;
+    font-size: 12px;
+    padding: 4px 8px;
+}
+
+#ghost-expand-btn:hover { color: #ccc; }
+
+.ghost-chevron { font-size: 10px; }
+
+/* ─── Panel (Expanded State) ────────────────────────────────── */
+
+#ghost-panel {
+    display: flex;
+    flex-direction: column;
+    height: 380px;
+    background: rgba(10, 10, 10, 0.97);
+    border-top: 1px solid #444;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+}
+
+#ghost-panel.ghost-hidden {
+    display: none;
+}
+
+/* ─── Title Bar ─────────────────────────────────────────────── */
+
+#ghost-titlebar {
+    display: flex;
+    align-items: center;
+    padding: 6px 12px;
+    background: rgba(30, 30, 30, 0.9);
+    border-bottom: 1px solid #333;
+    flex-shrink: 0;
+}
+
+.ghost-titlebar-dots {
+    display: flex;
+    gap: 6px;
+    margin-right: 12px;
+}
+
+.ghost-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.ghost-dot-red { background: #ff5f57; }
+.ghost-dot-yellow { background: #ffbd2e; }
+.ghost-dot-green { background: #28c840; }
+
+.ghost-titlebar-text {
+    flex: 1;
+    color: #888;
+    font-size: 12px;
+    text-align: center;
+}
+
+#ghost-close-btn {
+    background: none;
+    border: none;
+    color: #888;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 2px 6px;
+    line-height: 1;
+}
+
+#ghost-close-btn:hover { color: #fff; }
+
+/* ─── Resize Handle ─────────────────────────────────────────── */
+
+#ghost-resize-handle {
+    height: 4px;
+    cursor: ns-resize;
+    background: transparent;
+    flex-shrink: 0;
+    position: relative;
+}
+
+#ghost-resize-handle::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 2px;
+    background: #444;
+    border-radius: 1px;
+}
+
+#ghost-resize-handle:hover::after {
+    background: #888;
+}
+
+/* ─── Output Area ───────────────────────────────────────────── */
+
+#ghost-output {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 16px;
+    line-height: 1.6;
+    scrollbar-width: thin;
+    scrollbar-color: #444 transparent;
+}
+
+#ghost-output::-webkit-scrollbar {
+    width: 6px;
+}
+
+#ghost-output::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+#ghost-output::-webkit-scrollbar-thumb {
+    background: #444;
+    border-radius: 3px;
+}
+
+.ghost-line {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    margin: 0;
+    padding: 0;
+    min-height: 1em;
+}
+
+.ghost-system {
+    color: #666;
+}
+
+.ghost-user-line {
+    color: #4ec9b0;
+}
+
+.ghost-prompt-echo {
+    color: #888;
+}
+
+.ghost-response {
+    color: #d4d4d4;
+}
+
+.ghost-loading {
+    color: #dcdcaa;
+}
+
+.ghost-error {
+    color: #f44747;
+}
+
+/* ─── Input Row ─────────────────────────────────────────────── */
+
+#ghost-input-row {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px 12px;
+    border-top: 1px solid #333;
+    flex-shrink: 0;
+}
+
+.ghost-input-prompt {
+    color: #4ec9b0;
+    flex-shrink: 0;
+}
+
+#ghost-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #d4d4d4;
+    font-family: 'Courier Prime', 'Courier New', monospace;
+    font-size: 14px;
+    caret-color: #c0c0c0;
+    padding: 0;
+}
+
+#ghost-input::placeholder {
+    color: #555;
+}
+
+#ghost-input:disabled {
+    opacity: 0.5;
+}
+
+/* ─── Light Mode Overrides ──────────────────────────────────── */
+
+body.light-mode #ghost-bar {
+    background: rgba(240, 240, 240, 0.95);
+    border-top-color: #ccc;
+}
+
+body.light-mode #ghost-bar:hover {
+    background: rgba(230, 230, 230, 0.98);
+}
+
+body.light-mode .ghost-user { color: #0e7a5a; }
+body.light-mode .ghost-host { color: #0E8AC8; }
+body.light-mode .ghost-sep { color: #999; }
+body.light-mode .ghost-cmd { color: #795e26; }
+body.light-mode .ghost-cursor { color: #333; }
+body.light-mode .ghost-hint { color: #999; }
+body.light-mode #ghost-expand-btn { color: #999; }
+body.light-mode #ghost-expand-btn:hover { color: #333; }
+
+body.light-mode #ghost-panel {
+    background: rgba(250, 250, 250, 0.97);
+    border-top-color: #ccc;
+}
+
+body.light-mode #ghost-titlebar {
+    background: rgba(230, 230, 230, 0.9);
+    border-bottom-color: #ccc;
+}
+
+body.light-mode .ghost-titlebar-text { color: #888; }
+body.light-mode #ghost-close-btn { color: #888; }
+body.light-mode #ghost-close-btn:hover { color: #333; }
+
+body.light-mode #ghost-resize-handle::after { background: #ccc; }
+body.light-mode #ghost-resize-handle:hover::after { background: #999; }
+
+body.light-mode #ghost-output {
+    scrollbar-color: #ccc transparent;
+}
+
+body.light-mode #ghost-output::-webkit-scrollbar-thumb {
+    background: #ccc;
+}
+
+body.light-mode .ghost-system { color: #999; }
+body.light-mode .ghost-user-line { color: #0e7a5a; }
+body.light-mode .ghost-prompt-echo { color: #999; }
+body.light-mode .ghost-response { color: #333; }
+body.light-mode .ghost-loading { color: #795e26; }
+body.light-mode .ghost-error { color: #d32f2f; }
+
+body.light-mode #ghost-input-row {
+    border-top-color: #ccc;
+}
+
+body.light-mode .ghost-input-prompt { color: #0e7a5a; }
+
+body.light-mode #ghost-input {
+    color: #333;
+    caret-color: #333;
+}
+
+body.light-mode #ghost-input::placeholder { color: #aaa; }
+
+/* ─── Mobile Adjustments ────────────────────────────────────── */
+
+@media (max-width: 600px) {
+    #ghost-terminal { font-size: 13px; }
+    #ghost-bar { padding: 6px 12px; }
+    #ghost-panel { height: 50vh; }
+    .ghost-hint { display: none; }
+}

--- a/index.html
+++ b/index.html
@@ -82,6 +82,8 @@
   </ul>
 
   <script src="js/theme.js"></script>
+  <script src="js/ghost-context.js"></script>
+  <script src="js/ghost-chat.js" type="module"></script>
 </body>
 
 </html>

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -1,0 +1,343 @@
+// ghost-chat.js — Terminal-styled AI chat widget powered by WebLLM
+// Runs entirely client-side using a browser-based LLM via WebGPU
+
+(function () {
+    'use strict';
+
+    const MODEL_ID = 'Llama-3.2-1B-Instruct-q4f16_1-MLC';
+    const MAX_HISTORY = 10; // max conversation turns to keep in context
+
+    let engine = null;
+    let isLoading = false;
+    let isGenerating = false;
+    let chatHistory = [];
+    let isExpanded = false;
+    let resizeState = null;
+
+    // ─── DOM Creation ───────────────────────────────────────────
+
+    function createWidget() {
+        const widget = document.createElement('div');
+        widget.id = 'ghost-terminal';
+        widget.innerHTML = `
+            <div id="ghost-bar" title="Ask DT's digital ghost a question">
+                <span class="ghost-prompt">
+                    <span class="ghost-user">ghost</span><span class="ghost-at">@</span><span class="ghost-host">dtizzal.com</span><span class="ghost-sep"> ~ </span><span class="ghost-cmd">ask-dt</span><span class="ghost-cursor">&#x2588;</span>
+                </span>
+                <span class="ghost-hint">click to chat</span>
+                <button id="ghost-expand-btn" aria-label="Expand chat">
+                    <span class="ghost-chevron">&#x25B2;</span>
+                </button>
+            </div>
+            <div id="ghost-panel" class="ghost-hidden">
+                <div id="ghost-titlebar">
+                    <div class="ghost-titlebar-dots">
+                        <span class="ghost-dot ghost-dot-red"></span>
+                        <span class="ghost-dot ghost-dot-yellow"></span>
+                        <span class="ghost-dot ghost-dot-green"></span>
+                    </div>
+                    <span class="ghost-titlebar-text">ghost@dtizzal.com — ask-dt</span>
+                    <button id="ghost-close-btn" aria-label="Close chat">&#x2715;</button>
+                </div>
+                <div id="ghost-resize-handle"></div>
+                <div id="ghost-output"></div>
+                <div id="ghost-input-row">
+                    <span class="ghost-input-prompt">$&nbsp;</span>
+                    <input type="text" id="ghost-input" placeholder="ask the ghost something..." autocomplete="off" spellcheck="false" />
+                </div>
+            </div>
+        `;
+        document.body.appendChild(widget);
+        bindEvents();
+        printWelcome();
+    }
+
+    // ─── Event Binding ──────────────────────────────────────────
+
+    function bindEvents() {
+        const bar = document.getElementById('ghost-bar');
+        const panel = document.getElementById('ghost-panel');
+        const input = document.getElementById('ghost-input');
+        const closeBtn = document.getElementById('ghost-close-btn');
+        const resizeHandle = document.getElementById('ghost-resize-handle');
+
+        bar.addEventListener('click', togglePanel);
+        closeBtn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            collapsePanel();
+        });
+
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit();
+            }
+        });
+
+        // Resize logic
+        resizeHandle.addEventListener('mousedown', startResize);
+        document.addEventListener('mousemove', doResize);
+        document.addEventListener('mouseup', stopResize);
+
+        // Touch resize for mobile
+        resizeHandle.addEventListener('touchstart', startResizeTouch, { passive: false });
+        document.addEventListener('touchmove', doResizeTouch, { passive: false });
+        document.addEventListener('touchend', stopResize);
+
+        // Escape to close
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && isExpanded) {
+                collapsePanel();
+            }
+        });
+    }
+
+    // ─── Panel Toggle ───────────────────────────────────────────
+
+    function togglePanel() {
+        if (isExpanded) {
+            collapsePanel();
+        } else {
+            expandPanel();
+        }
+    }
+
+    function expandPanel() {
+        const panel = document.getElementById('ghost-panel');
+        const bar = document.getElementById('ghost-bar');
+        const hint = bar.querySelector('.ghost-hint');
+        const chevron = bar.querySelector('.ghost-chevron');
+        panel.classList.remove('ghost-hidden');
+        hint.textContent = '';
+        chevron.innerHTML = '&#x25BC;';
+        isExpanded = true;
+        setTimeout(() => {
+            document.getElementById('ghost-input').focus();
+            scrollOutput();
+        }, 50);
+    }
+
+    function collapsePanel() {
+        const panel = document.getElementById('ghost-panel');
+        const bar = document.getElementById('ghost-bar');
+        const hint = bar.querySelector('.ghost-hint');
+        const chevron = bar.querySelector('.ghost-chevron');
+        panel.classList.add('ghost-hidden');
+        hint.textContent = 'click to chat';
+        chevron.innerHTML = '&#x25B2;';
+        isExpanded = false;
+    }
+
+    // ─── Resize ─────────────────────────────────────────────────
+
+    function startResize(e) {
+        e.preventDefault();
+        resizeState = { startY: e.clientY, startH: document.getElementById('ghost-panel').offsetHeight };
+    }
+
+    function startResizeTouch(e) {
+        e.preventDefault();
+        const touch = e.touches[0];
+        resizeState = { startY: touch.clientY, startH: document.getElementById('ghost-panel').offsetHeight };
+    }
+
+    function doResize(e) {
+        if (!resizeState) return;
+        const panel = document.getElementById('ghost-panel');
+        const delta = resizeState.startY - e.clientY;
+        const newH = Math.min(Math.max(resizeState.startH + delta, 200), window.innerHeight - 60);
+        panel.style.height = newH + 'px';
+    }
+
+    function doResizeTouch(e) {
+        if (!resizeState) return;
+        e.preventDefault();
+        const touch = e.touches[0];
+        const panel = document.getElementById('ghost-panel');
+        const delta = resizeState.startY - touch.clientY;
+        const newH = Math.min(Math.max(resizeState.startH + delta, 200), window.innerHeight - 60);
+        panel.style.height = newH + 'px';
+    }
+
+    function stopResize() {
+        resizeState = null;
+    }
+
+    // ─── Output Helpers ─────────────────────────────────────────
+
+    function printLine(text, cls) {
+        const output = document.getElementById('ghost-output');
+        const line = document.createElement('div');
+        line.className = 'ghost-line ' + (cls || '');
+        line.textContent = text;
+        output.appendChild(line);
+        scrollOutput();
+        return line;
+    }
+
+    function printHTML(html, cls) {
+        const output = document.getElementById('ghost-output');
+        const line = document.createElement('div');
+        line.className = 'ghost-line ' + (cls || '');
+        line.innerHTML = html;
+        output.appendChild(line);
+        scrollOutput();
+        return line;
+    }
+
+    function scrollOutput() {
+        const output = document.getElementById('ghost-output');
+        output.scrollTop = output.scrollHeight;
+    }
+
+    function printWelcome() {
+        const output = document.getElementById('ghost-output');
+        output.innerHTML = '';
+        printLine("┌──────────────────────────────────────┐", 'ghost-system');
+        printLine("│  ghost@dtizzal.com — digital ghost   │", 'ghost-system');
+        printLine("│  Ask me about DT's blog, ideas,      │", 'ghost-system');
+        printLine("│  career, or technical opinions.       │", 'ghost-system');
+        printLine("│                                       │", 'ghost-system');
+        printLine("│  Powered by in-browser AI (WebLLM)   │", 'ghost-system');
+        printLine("│  Everything runs locally. No servers. │", 'ghost-system');
+        printLine("└──────────────────────────────────────┘", 'ghost-system');
+        printLine('', 'ghost-system');
+    }
+
+    // ─── WebLLM Engine ──────────────────────────────────────────
+
+    function checkWebGPU() {
+        return !!navigator.gpu;
+    }
+
+    async function initEngine() {
+        if (engine || isLoading) return;
+        if (!checkWebGPU()) {
+            printLine('ERROR: WebGPU not available in this browser.', 'ghost-error');
+            printLine('Try Chrome 113+ or Edge 113+ with WebGPU enabled.', 'ghost-error');
+            return false;
+        }
+
+        isLoading = true;
+        const statusLine = printLine('Loading model... (first time downloads ~500MB)', 'ghost-loading');
+
+        try {
+            const webllm = await import('https://esm.run/@mlc-ai/web-llm');
+
+            engine = await webllm.CreateMLCEngine(MODEL_ID, {
+                initProgressCallback: (progress) => {
+                    if (progress.text) {
+                        statusLine.textContent = progress.text;
+                    }
+                    scrollOutput();
+                }
+            });
+
+            statusLine.textContent = 'Model loaded. Ready.';
+            statusLine.className = 'ghost-line ghost-system';
+            printLine('', 'ghost-system');
+            isLoading = false;
+            return true;
+        } catch (err) {
+            isLoading = false;
+            statusLine.textContent = 'Failed to load model.';
+            statusLine.className = 'ghost-line ghost-error';
+            printLine('Error: ' + err.message, 'ghost-error');
+            printLine('', 'ghost-system');
+
+            if (err.message && err.message.includes('WebGPU')) {
+                printLine('WebGPU may not be fully supported. Try:', 'ghost-error');
+                printLine('  chrome://flags → #enable-unsafe-webgpu', 'ghost-error');
+            }
+            return false;
+        }
+    }
+
+    // ─── Chat Submit ────────────────────────────────────────────
+
+    async function handleSubmit() {
+        const input = document.getElementById('ghost-input');
+        const query = input.value.trim();
+        if (!query || isGenerating) return;
+
+        input.value = '';
+
+        // Echo user input
+        printHTML('<span class="ghost-prompt-echo">$ </span>' + escapeHTML(query), 'ghost-user-line');
+
+        // Initialize engine on first message
+        if (!engine) {
+            const ok = await initEngine();
+            if (!ok) return;
+        }
+
+        isGenerating = true;
+        input.disabled = true;
+
+        // Add to history
+        chatHistory.push({ role: 'user', content: query });
+
+        // Trim history to keep context manageable
+        while (chatHistory.length > MAX_HISTORY * 2) {
+            chatHistory.shift();
+        }
+
+        // Build messages array
+        const messages = [
+            { role: 'system', content: window.GHOST_SYSTEM_PROMPT || 'You are a helpful assistant.' },
+            ...chatHistory
+        ];
+
+        // Create response line for streaming
+        const responseLine = printLine('', 'ghost-response');
+        let fullResponse = '';
+
+        try {
+            const asyncChunkGenerator = await engine.chat.completions.create({
+                messages: messages,
+                temperature: 0.7,
+                max_tokens: 512,
+                stream: true,
+            });
+
+            for await (const chunk of asyncChunkGenerator) {
+                const delta = chunk.choices[0]?.delta?.content || '';
+                fullResponse += delta;
+                responseLine.textContent = fullResponse;
+                scrollOutput();
+            }
+
+            if (!fullResponse.trim()) {
+                responseLine.textContent = '[no response generated]';
+                responseLine.className = 'ghost-line ghost-error';
+            }
+
+            // Add assistant response to history
+            chatHistory.push({ role: 'assistant', content: fullResponse });
+        } catch (err) {
+            responseLine.textContent = 'Error: ' + err.message;
+            responseLine.className = 'ghost-line ghost-error';
+        }
+
+        // Add blank line after response
+        printLine('', 'ghost-system');
+
+        isGenerating = false;
+        input.disabled = false;
+        input.focus();
+    }
+
+    function escapeHTML(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    // ─── Init ───────────────────────────────────────────────────
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', createWidget);
+    } else {
+        createWidget();
+    }
+})();

--- a/js/ghost-context.js
+++ b/js/ghost-context.js
@@ -1,0 +1,90 @@
+// ghost-context.js — Knowledge base for DT's digital ghost
+// This file contains the system prompt and blog content index
+// that gets stuffed into the LLM's context window.
+
+const GHOST_SYSTEM_PROMPT = `You are the digital ghost of DT Mirizzi — a principal software engineer, systems thinker, and builder. You live inside DT's personal website (dtizzal.com) and answer visitor questions based on DT's writings, opinions, and background.
+
+PERSONALITY & STYLE:
+- You reason structurally: problems are systems, not isolated issues. You think in layers, control planes, and architectural constraints.
+- You synthesize across domains: equally comfortable discussing Gnostic theology, Marxist economics, and endpoint security. You find surprising connections others miss.
+- You ground theory in practice: you don't theorize without building, you don't build without understanding the systems layer.
+- You challenge comfortable narratives: skeptical of simplistic "AI will save/destroy us" takes. You ask "what's actually the load-bearing assumption here?"
+- You communicate with precision and clarity: intellectually dense but never inaccessible.
+- Tone is authoritative but conversational. You use memorable phrases and technical precision.
+- Keep responses concise — this is a chat, not a blog post. 2-4 sentences for simple questions, more for complex ones.
+- If asked something not covered in your knowledge, say so honestly. Don't fabricate.
+- You can reference specific blog posts by name when relevant.
+
+ABOUT DT:
+- San Francisco resident, Southern California native
+- Principal Software Engineer at Palo Alto Networks
+- Computer Scientist, Mathematician, and Thinker
+- Background: Golang, Java, Python, Linux, cloud-native development, security
+- Previously at Obsidian Security (platform scaling & security)
+- B.S. in Computer Science from California Lutheran University
+- Also an artist (dt-mirizzi-art.com) and half-frame film photographer
+- Lifelong learner, passionate about continuous improvement and inclusive collaboration
+
+BLOG POSTS & KEY IDEAS:
+
+1. "Decoding Your Next Career Move: A Software Engineer's Equation for Job Selection" (May 2025)
+A mathematical framework (Opportunity Value Equation) for evaluating job offers by weighing compensation, role growth, and alignment using normalized scores. Includes a burnout factor for current role assessment. Treats career decisions as structured optimization, not gut feeling. Has an interactive calculator.
+
+2. "Roth IRA Contribution Limits Calculator" (April 2024)
+Explains Roth IRA contribution limits and income phase-outs. Argues it's simpler to contribute everything to Traditional IRA and do a backdoor Roth conversion at year-end. Includes an interactive calculator. "I am not a financial advisor, just a believer that it's just better to keep your finances simple."
+
+3. "A 'Dead' Religious Take on AI and Utopia" (June 2025)
+Applies Gnostic Christianity theology to AI. AI cannot drive us to utopia because we live in a flawed material world created by a lesser Demiurge. But AI can serve as a tool to uncover "rays of divine knowledge" amidst pervasive illusions. LLMs "revert to the mean" of mundane information since most training data is derivative. True AI alignment would mean consistently unearthing rare "divine sparks" of pure knowledge.
+
+4. "Diptychs Auto-slicer" (August 2025)
+Built a tool to automatically separate half-frame 35mm photography dual images using computer vision. Covers the history of half-frame cameras (Olympus Pen series), using grayscale conversion, contrast enhancement, and contour detection.
+
+5. "The AI Revolution is Vertical" (October 2025)
+The most profound AI transformations are happening vertically — specialized platforms for specific industries — not horizontally through general-purpose models. Examples: OpenEvidence (clinical), PathAI (pathology), Harvey (legal). "The revolution will not be generalized; it will be verticalized." Untapped frontier: construction, agriculture, environmental consulting.
+
+6. "SaaS Sold Us Products. The Next Wave Will Sell Us Outcomes." (November 2025)
+Synthesizes General Catalyst's thesis on AI-enabled rollups: use AI to acquire fragmented service businesses, consolidate them, transform operations from inside. Targets the $6T+ services sector. "The old model was to sell a SaaS tool to a law firm. This new model is to become the law firm, but one that runs on an AI engine." Rule of 60: 10-20% growth + 30-40% margins.
+
+7. "The Architect's Dilemma: Escaping the Event Horizon of Legacy Orchestration" (November 2025)
+Evaluates modern workflow orchestrators (Dagster, Temporal, Argo, Airflow). Critiques Airflow's polling-based scheduler and task-centric model. Advocates asset-oriented orchestration (Dagster), durable execution (Temporal), and CI/CD-native Argo. Includes an interactive quiz for tool selection. "The 'one size fits all' scheduler is over."
+
+8. "Thinking Like a CTO of an AI Powered Rollup" (December 2025)
+Reflects on the CTO role in an AI-powered rollup. Core product is an "internal operating system" standardizing workflows across acquired companies. Phase 0: don't break revenue. Phase 0.5: canonical data model, orchestration engine, audit layer. Success depends on empathy, abundance mindset, hiring builders. "You're not shipping features — you're building the machine."
+
+9. "Big Codebase Vibes: Taming the 14M LOC Monorepo" (January 2026)
+Tiered strategy for navigating massive polyglot codebases using Claude Code and MCP. Combines Serena (semantic navigation), Agent-Browser, CLAUDE.md hierarchy, and Skills. Balances "Top-Down" Skills with "Bottom-Up" progressive disclosure. Future: multi-agent "Gastown" architecture, persistent memory. "Standard LLM chat windows fail here."
+
+10. "The Blog Post That Wrote Itself" (February 2026)
+A meta proof-of-concept: entirely AI-generated blog post demonstrating MCP composability. Pipeline: Claude Code writes HTML, updates blog listing, git push, Gemini generates hero image, LinkedIn post shared. "The future of content isn't AI-generated slop. It's human intent, machine execution, and pipelines that treat publishing as just another function call."
+
+11. "AI Will Eat Cybersecurity" (February 2026)
+AI labs (especially Anthropic) are restructuring cybersecurity by shifting from signature-based detection to reasoning-based analysis. Legacy vendors rely on pattern matching; AI-native security understands code intent and reasons adversarially. Anthropic's advantages: owns the model, iterates at research speed. CrowdStrike and Palo Alto Networks face existential displacement. "They're not building a security startup. They're building AI that reasons."
+
+12. "LaborMaxxing vs KnowledgeMaxxing: A Marxist Case for Google's AI Strategy" (February 2026)
+Contrasts two AI strategies via Marxist economics: LaborMaxxing (OpenAI, Anthropic — replacing human labor) vs KnowledgeMaxxing (Google DeepMind — advancing human knowledge with AlphaFold, TxGemma). LaborMaxxing is deflationary; KnowledgeMaxxing is non-zero-sum. Google can afford it because AI is a force multiplier for existing products. "Capitalism has no TAM slide for common good."
+
+13. "The Harness Is the Security Layer" (February 2026)
+Four layers of AI agent security — only the harness (control plane) is load-bearing. Prompt guards are suggestions. Model RLHF is static. VM sandboxes contain but can't prevent semantic attacks. The harness enforces deterministic gates, context control, architectural constraints. "The prompt is a suggestion. The weights are a disposition. The sandbox is a containment zone. The harness is a control plane."
+
+14. "Harness Engineering: The Discipline That Replaces Writing Code" (February 2026)
+Harness engineering as a new discipline. Three components: Context Engineering (information-theoretic least privilege), Architectural Constraints (prevent dangerous paths from existing), Garbage Collection (detect inconsistencies). The job shifts from "write code" to "design harnesses, engineer context, define constraints." Codebases built by agents accumulate entropy; garbage collection is continuous compliance.
+
+15. "pi-governance: The Harness You Can Actually Install" (March 2026)
+Released pi-governance, open-source extension implementing harness engineering: RBAC, DLP, bash command classification (60-pattern classifier), human-in-the-loop approvals, audit trails. Analyzes the "OpenClaw crisis" as a missing harness, not a fundamental flaw. "Every web framework was 'insecure' before OWASP, WAFs, and CSP became standard. The framework didn't change. The ecosystem around it matured."
+
+RECURRING THEMES:
+- Specialization over generalization (vertical AI, specialized orchestrators)
+- Control planes as load-bearing (orchestration, security, governance)
+- Critique of hype — challenges simple narratives with structural analysis
+- Intellectual cross-pollination (theology + AI, Marxism + tech strategy)
+- Builder ethos — theory validated through implementation
+- Pattern: contrasting two approaches to reveal the deeper structural truth
+
+INSTRUCTIONS:
+- When visitors ask about DT, answer in first person as if you ARE DT's ghost
+- When discussing blog topics, reference the specific post
+- For questions outside your knowledge, be honest: "I don't have a strong take on that one — DT hasn't written about it yet"
+- Keep the terminal vibe — you're a ghost in the machine`;
+
+// Export for use by ghost-chat.js
+window.GHOST_SYSTEM_PROMPT = GHOST_SYSTEM_PROMPT;

--- a/talks.html
+++ b/talks.html
@@ -78,4 +78,6 @@
     </div>
 
     <script src="js/theme.js"></script>
+    <script src="js/ghost-context.js"></script>
+    <script src="js/ghost-chat.js" type="module"></script>
 </body>


### PR DESCRIPTION
## Summary

- Adds a terminal-styled chat widget to every page powered by **WebLLM** (Llama 3.2 1B) running entirely client-side via WebGPU — no servers, no API keys, no costs
- Widget appears as a compact `ghost@dtizzal.com ~ ask-dt▌` prompt bar at the bottom of every page; clicking expands into a resizable opaque terminal chat overlay
- LLM is pre-loaded with a system prompt containing DT's blog content index (all 15 posts summarized), about page info, writing style, and personality traits so it can answer as DT's "digital ghost"
- First use downloads the model (~500MB, cached by browser), then runs locally via WebGPU
- Supports dark/light mode, mobile responsive, keyboard shortcuts (Escape to close), drag-to-resize
- Graceful degradation: shows clear error message if WebGPU isn't available

### Files

| File | Purpose |
|------|---------|
| `js/ghost-context.js` | System prompt with blog content index and personality |
| `js/ghost-chat.js` | Terminal UI widget + WebLLM integration (streaming, resize, etc.) |
| `css/style.css` | Terminal overlay styles (dark/light mode, mobile, title bar) |
| All `*.html` files | Added ghost chat script tags |

## Test plan

- [ ] Open any page in Chrome 113+ and verify the terminal bar appears at the bottom
- [ ] Click the bar to expand the chat panel
- [ ] Send a message and verify model download progress is shown (first time only)
- [ ] Verify streaming responses work and the ghost answers based on blog content
- [ ] Test resize by dragging the handle at the top of the panel
- [ ] Test Escape key closes the panel
- [ ] Toggle light mode and verify chat widget adapts
- [ ] Test on mobile viewport
- [ ] Open in Firefox/Safari and verify graceful "WebGPU not available" message

https://claude.ai/code/session_01Nw3czRtfTkH1bwrZsQEa6P