### PR TITLE
Add browser-based AI chatbot ("digital ghost")

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -763,8 +763,8 @@ body.light-mode .legend-percent {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background: rgba(10, 10, 10, 0.95);
-    border-top: 1px solid #333;
+    background: rgba(40, 40, 40, 0.75);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
     padding: 8px 16px;
     cursor: pointer;
     user-select: none;
@@ -773,7 +773,7 @@ body.light-mode .legend-percent {
 }
 
 #ghost-bar:hover {
-    background: rgba(20, 20, 20, 0.98);
+    background: rgba(50, 50, 50, 0.8);
 }
 
 .ghost-prompt {
@@ -782,14 +782,14 @@ body.light-mode .legend-percent {
     gap: 0;
 }
 
-.ghost-user { color: #4ec9b0; }
-.ghost-at { color: #888; }
-.ghost-host { color: #569cd6; }
-.ghost-sep { color: #888; }
-.ghost-cmd { color: #dcdcaa; }
+.ghost-user { color: rgba(255, 255, 255, 0.5); }
+.ghost-at { color: rgba(255, 255, 255, 0.25); }
+.ghost-host { color: rgba(255, 255, 255, 0.5); }
+.ghost-sep { color: rgba(255, 255, 255, 0.25); }
+.ghost-cmd { color: rgba(255, 255, 255, 0.6); }
 
 .ghost-cursor {
-    color: #c0c0c0;
+    color: rgba(255, 255, 255, 0.4);
     animation: ghost-blink 1s step-end infinite;
     font-size: 12px;
     margin-left: 2px;
@@ -801,7 +801,7 @@ body.light-mode .legend-percent {
 }
 
 .ghost-hint {
-    color: #666;
+    color: rgba(255, 255, 255, 0.25);
     font-size: 12px;
     flex: 1;
     text-align: right;
@@ -811,13 +811,13 @@ body.light-mode .legend-percent {
 #ghost-expand-btn {
     background: none;
     border: none;
-    color: #888;
+    color: rgba(255, 255, 255, 0.3);
     cursor: pointer;
     font-size: 12px;
     padding: 4px 8px;
 }
 
-#ghost-expand-btn:hover { color: #ccc; }
+#ghost-expand-btn:hover { color: rgba(255, 255, 255, 0.6); }
 
 .ghost-chevron { font-size: 10px; }
 
@@ -827,8 +827,8 @@ body.light-mode .legend-percent {
     display: flex;
     flex-direction: column;
     height: 380px;
-    background: rgba(10, 10, 10, 0.97);
-    border-top: 1px solid #444;
+    background: rgba(30, 30, 30, 0.75);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
 }
@@ -836,52 +836,6 @@ body.light-mode .legend-percent {
 #ghost-panel.ghost-hidden {
     display: none;
 }
-
-/* ─── Title Bar ─────────────────────────────────────────────── */
-
-#ghost-titlebar {
-    display: flex;
-    align-items: center;
-    padding: 6px 12px;
-    background: rgba(30, 30, 30, 0.9);
-    border-bottom: 1px solid #333;
-    flex-shrink: 0;
-}
-
-.ghost-titlebar-dots {
-    display: flex;
-    gap: 6px;
-    margin-right: 12px;
-}
-
-.ghost-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-}
-
-.ghost-dot-red { background: #ff5f57; }
-.ghost-dot-yellow { background: #ffbd2e; }
-.ghost-dot-green { background: #28c840; }
-
-.ghost-titlebar-text {
-    flex: 1;
-    color: #888;
-    font-size: 12px;
-    text-align: center;
-}
-
-#ghost-close-btn {
-    background: none;
-    border: none;
-    color: #888;
-    cursor: pointer;
-    font-size: 14px;
-    padding: 2px 6px;
-    line-height: 1;
-}
-
-#ghost-close-btn:hover { color: #fff; }
 
 /* ─── Resize Handle ─────────────────────────────────────────── */
 
@@ -901,12 +855,12 @@ body.light-mode .legend-percent {
     transform: translate(-50%, -50%);
     width: 40px;
     height: 2px;
-    background: #444;
+    background: rgba(255, 255, 255, 0.12);
     border-radius: 1px;
 }
 
 #ghost-resize-handle:hover::after {
-    background: #888;
+    background: rgba(255, 255, 255, 0.3);
 }
 
 /* ─── Output Area ───────────────────────────────────────────── */
@@ -917,7 +871,7 @@ body.light-mode .legend-percent {
     padding: 12px 16px;
     line-height: 1.6;
     scrollbar-width: thin;
-    scrollbar-color: #444 transparent;
+    scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
 }
 
 #ghost-output::-webkit-scrollbar {
@@ -929,7 +883,7 @@ body.light-mode .legend-percent {
 }
 
 #ghost-output::-webkit-scrollbar-thumb {
-    background: #444;
+    background: rgba(255, 255, 255, 0.1);
     border-radius: 3px;
 }
 
@@ -942,27 +896,27 @@ body.light-mode .legend-percent {
 }
 
 .ghost-system {
-    color: #666;
+    color: rgba(255, 255, 255, 0.3);
 }
 
 .ghost-user-line {
-    color: #4ec9b0;
+    color: rgba(255, 255, 255, 0.6);
 }
 
 .ghost-prompt-echo {
-    color: #888;
+    color: rgba(255, 255, 255, 0.3);
 }
 
 .ghost-response {
-    color: #d4d4d4;
+    color: rgba(255, 255, 255, 0.7);
 }
 
 .ghost-loading {
-    color: #dcdcaa;
+    color: rgba(255, 255, 255, 0.45);
 }
 
 .ghost-error {
-    color: #f44747;
+    color: rgba(255, 120, 120, 0.7);
 }
 
 /* ─── Input Row ─────────────────────────────────────────────── */
@@ -971,12 +925,12 @@ body.light-mode .legend-percent {
     display: flex;
     align-items: center;
     padding: 8px 16px 12px;
-    border-top: 1px solid #333;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
 }
 
 .ghost-input-prompt {
-    color: #4ec9b0;
+    color: rgba(255, 255, 255, 0.4);
     flex-shrink: 0;
 }
 
@@ -985,15 +939,15 @@ body.light-mode .legend-percent {
     background: transparent;
     border: none;
     outline: none;
-    color: #d4d4d4;
+    color: rgba(255, 255, 255, 0.7);
     font-family: 'Courier Prime', 'Courier New', monospace;
     font-size: 14px;
-    caret-color: #c0c0c0;
+    caret-color: rgba(255, 255, 255, 0.5);
     padding: 0;
 }
 
 #ghost-input::placeholder {
-    color: #555;
+    color: rgba(255, 255, 255, 0.2);
 }
 
 #ghost-input:disabled {
@@ -1003,67 +957,59 @@ body.light-mode .legend-percent {
 /* ─── Light Mode Overrides ──────────────────────────────────── */
 
 body.light-mode #ghost-bar {
-    background: rgba(240, 240, 240, 0.95);
-    border-top-color: #ccc;
+    background: rgba(200, 200, 200, 0.6);
+    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
 body.light-mode #ghost-bar:hover {
-    background: rgba(230, 230, 230, 0.98);
+    background: rgba(190, 190, 190, 0.7);
 }
 
-body.light-mode .ghost-user { color: #0e7a5a; }
-body.light-mode .ghost-host { color: #0E8AC8; }
-body.light-mode .ghost-sep { color: #999; }
-body.light-mode .ghost-cmd { color: #795e26; }
-body.light-mode .ghost-cursor { color: #333; }
-body.light-mode .ghost-hint { color: #999; }
-body.light-mode #ghost-expand-btn { color: #999; }
-body.light-mode #ghost-expand-btn:hover { color: #333; }
+body.light-mode .ghost-user { color: rgba(0, 0, 0, 0.4); }
+body.light-mode .ghost-at { color: rgba(0, 0, 0, 0.2); }
+body.light-mode .ghost-host { color: rgba(0, 0, 0, 0.4); }
+body.light-mode .ghost-sep { color: rgba(0, 0, 0, 0.2); }
+body.light-mode .ghost-cmd { color: rgba(0, 0, 0, 0.5); }
+body.light-mode .ghost-cursor { color: rgba(0, 0, 0, 0.3); }
+body.light-mode .ghost-hint { color: rgba(0, 0, 0, 0.25); }
+body.light-mode #ghost-expand-btn { color: rgba(0, 0, 0, 0.25); }
+body.light-mode #ghost-expand-btn:hover { color: rgba(0, 0, 0, 0.5); }
 
 body.light-mode #ghost-panel {
-    background: rgba(250, 250, 250, 0.97);
-    border-top-color: #ccc;
+    background: rgba(220, 220, 220, 0.7);
+    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
-body.light-mode #ghost-titlebar {
-    background: rgba(230, 230, 230, 0.9);
-    border-bottom-color: #ccc;
-}
-
-body.light-mode .ghost-titlebar-text { color: #888; }
-body.light-mode #ghost-close-btn { color: #888; }
-body.light-mode #ghost-close-btn:hover { color: #333; }
-
-body.light-mode #ghost-resize-handle::after { background: #ccc; }
-body.light-mode #ghost-resize-handle:hover::after { background: #999; }
+body.light-mode #ghost-resize-handle::after { background: rgba(0, 0, 0, 0.1); }
+body.light-mode #ghost-resize-handle:hover::after { background: rgba(0, 0, 0, 0.25); }
 
 body.light-mode #ghost-output {
-    scrollbar-color: #ccc transparent;
+    scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
 }
 
 body.light-mode #ghost-output::-webkit-scrollbar-thumb {
-    background: #ccc;
+    background: rgba(0, 0, 0, 0.1);
 }
 
-body.light-mode .ghost-system { color: #999; }
-body.light-mode .ghost-user-line { color: #0e7a5a; }
-body.light-mode .ghost-prompt-echo { color: #999; }
-body.light-mode .ghost-response { color: #333; }
-body.light-mode .ghost-loading { color: #795e26; }
-body.light-mode .ghost-error { color: #d32f2f; }
+body.light-mode .ghost-system { color: rgba(0, 0, 0, 0.3); }
+body.light-mode .ghost-user-line { color: rgba(0, 0, 0, 0.5); }
+body.light-mode .ghost-prompt-echo { color: rgba(0, 0, 0, 0.3); }
+body.light-mode .ghost-response { color: rgba(0, 0, 0, 0.6); }
+body.light-mode .ghost-loading { color: rgba(0, 0, 0, 0.4); }
+body.light-mode .ghost-error { color: rgba(180, 50, 50, 0.7); }
 
 body.light-mode #ghost-input-row {
-    border-top-color: #ccc;
+    border-top-color: rgba(0, 0, 0, 0.08);
 }
 
-body.light-mode .ghost-input-prompt { color: #0e7a5a; }
+body.light-mode .ghost-input-prompt { color: rgba(0, 0, 0, 0.35); }
 
 body.light-mode #ghost-input {
-    color: #333;
-    caret-color: #333;
+    color: rgba(0, 0, 0, 0.6);
+    caret-color: rgba(0, 0, 0, 0.4);
 }
 
-body.light-mode #ghost-input::placeholder { color: #aaa; }
+body.light-mode #ghost-input::placeholder { color: rgba(0, 0, 0, 0.2); }
 
 /* ─── Mobile Adjustments ────────────────────────────────────── */
 

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -30,15 +30,6 @@
                 </button>
             </div>
             <div id="ghost-panel" class="ghost-hidden">
-                <div id="ghost-titlebar">
-                    <div class="ghost-titlebar-dots">
-                        <span class="ghost-dot ghost-dot-red"></span>
-                        <span class="ghost-dot ghost-dot-yellow"></span>
-                        <span class="ghost-dot ghost-dot-green"></span>
-                    </div>
-                    <span class="ghost-titlebar-text">ghost@dtizzal.com — ask-dt</span>
-                    <button id="ghost-close-btn" aria-label="Close chat">&#x2715;</button>
-                </div>
                 <div id="ghost-resize-handle"></div>
                 <div id="ghost-output"></div>
                 <div id="ghost-input-row">
@@ -58,14 +49,9 @@
         const bar = document.getElementById('ghost-bar');
         const panel = document.getElementById('ghost-panel');
         const input = document.getElementById('ghost-input');
-        const closeBtn = document.getElementById('ghost-close-btn');
         const resizeHandle = document.getElementById('ghost-resize-handle');
 
         bar.addEventListener('click', togglePanel);
-        closeBtn.addEventListener('click', function (e) {
-            e.stopPropagation();
-            collapsePanel();
-        });
 
         input.addEventListener('keydown', function (e) {
             if (e.key === 'Enter' && !e.shiftKey) {


### PR DESCRIPTION
## Summary

- Adds a terminal-styled chat widget to every page powered by **WebLLM** (Qwen3 0.6B) running entirely client-side via WebGPU — no servers, no API keys, no costs
- Widget appears as a compact muted `ghost@dtizzal.com ~ ask-dt` prompt bar at the bottom of every page; clicking expands into a resizable transparent grey terminal overlay
- LLM is pre-loaded with a system prompt containing DT's blog content index (all 15 posts summarized), about page info, writing style, and personality traits so it can answer as DT's "digital ghost"
- First use downloads the model (~300MB, cached by browser), then runs locally via WebGPU
- All text uses muted white tones, backgrounds are dark transparent overlays that let page content bleed through
- Supports dark/light mode, mobile responsive, keyboard shortcuts (Escape to close), drag-to-resize
- Mobile: warns about memory limits, caps responses to 192 tokens and 3 turns of history, OOM error recovery

### Model Choice
- **Qwen3-0.6B-q4f16_1-MLC** — ~300MB download, ~950MB VRAM, small enough for mobile Safari WebGPU
- WebLLM pinned to v0.2.82 (latest stable with Qwen3 support)
- Loading spinner shown while LLM generates responses

### Files

| File | Purpose |
|------|---------|
| `js/ghost-context.js` | System prompt with blog content index and personality |
| `js/ghost-chat.js` | Terminal UI widget + WebLLM integration (streaming, resize, mobile limits) |
| `css/style.css` | Dark transparent overlay styles, muted white text, spinner, dark/light mode |
| All `*.html` files | Added ghost chat script tags |

## Test plan

- [ ] Open any page in Chrome 113+ and verify the terminal bar appears at the bottom
- [ ] Click the bar to expand the chat panel
- [ ] Send a message and verify spinner shows, then model download progress (first time only)
- [ ] Verify streaming responses work and the ghost answers based on blog content
- [ ] Test on iPhone Safari — should show mobile warning, respond without crashing
- [ ] Test resize by dragging the handle at the top of the panel
- [ ] Test Escape key closes the panel
- [ ] Toggle light mode and verify chat widget adapts
- [ ] Open in Firefox/Safari desktop and verify graceful "WebGPU not available" message

https://claude.ai/code/session_01Nw3czRtfTkH1bwrZsQEa6P