### PR TITLE
Add in-browser AI chatbot with multi-model selector

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -763,17 +763,17 @@ body.light-mode .legend-percent {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background: rgba(40, 40, 40, 0.75);
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(15, 15, 15, 0.65);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
     padding: 8px 16px;
     cursor: pointer;
     user-select: none;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
 #ghost-bar:hover {
-    background: rgba(50, 50, 50, 0.8);
+    background: rgba(20, 20, 20, 0.72);
 }
 
 .ghost-prompt {
@@ -827,10 +827,10 @@ body.light-mode .legend-percent {
     display: flex;
     flex-direction: column;
     height: 380px;
-    background: rgba(30, 30, 30, 0.75);
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    background: rgba(10, 10, 10, 0.6);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
 }
 
 #ghost-panel.ghost-hidden {
@@ -919,6 +919,39 @@ body.light-mode .legend-percent {
     color: rgba(255, 120, 120, 0.7);
 }
 
+/* ─── Ghost Spinner ────────────────────────────────────────── */
+
+.ghost-spinner {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.ghost-spinner::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-top-color: rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    animation: ghost-spin 0.8s linear infinite;
+}
+
+@keyframes ghost-spin {
+    to { transform: rotate(360deg); }
+}
+
+body.light-mode .ghost-spinner {
+    color: rgba(0, 0, 0, 0.4);
+}
+
+body.light-mode .ghost-spinner::before {
+    border-color: rgba(0, 0, 0, 0.1);
+    border-top-color: rgba(0, 0, 0, 0.45);
+}
+
 /* ─── Input Row ─────────────────────────────────────────────── */
 
 #ghost-input-row {
@@ -957,12 +990,12 @@ body.light-mode .legend-percent {
 /* ─── Light Mode Overrides ──────────────────────────────────── */
 
 body.light-mode #ghost-bar {
-    background: rgba(200, 200, 200, 0.6);
-    border-top-color: rgba(0, 0, 0, 0.08);
+    background: rgba(160, 160, 160, 0.5);
+    border-top-color: rgba(0, 0, 0, 0.06);
 }
 
 body.light-mode #ghost-bar:hover {
-    background: rgba(190, 190, 190, 0.7);
+    background: rgba(150, 150, 150, 0.58);
 }
 
 body.light-mode .ghost-user { color: rgba(0, 0, 0, 0.4); }
@@ -976,8 +1009,8 @@ body.light-mode #ghost-expand-btn { color: rgba(0, 0, 0, 0.25); }
 body.light-mode #ghost-expand-btn:hover { color: rgba(0, 0, 0, 0.5); }
 
 body.light-mode #ghost-panel {
-    background: rgba(220, 220, 220, 0.7);
-    border-top-color: rgba(0, 0, 0, 0.08);
+    background: rgba(180, 180, 180, 0.55);
+    border-top-color: rgba(0, 0, 0, 0.06);
 }
 
 body.light-mode #ghost-resize-handle::after { background: rgba(0, 0, 0, 0.1); }

--- a/css/style.css
+++ b/css/style.css
@@ -752,9 +752,15 @@ body.light-mode .legend-percent {
     bottom: 0;
     left: 0;
     right: 0;
+    width: 100%;
     z-index: 9999;
     font-family: 'Courier Prime', 'Courier New', monospace;
     font-size: 14px;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* ─── Bottom Bar (Collapsed State) ──────────────────────────── */

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -4,9 +4,9 @@
 (function () {
     'use strict';
 
-    const MODEL_ID = 'Llama-3.2-1B-Instruct-q4f16_1-MLC';
+    const MODEL_ID = 'Qwen3-0.6B-q4f16_1-MLC';
     const MAX_HISTORY = 10; // max conversation turns to keep in context
-    const WEBLLM_VERSION = '0.2.78'; // pinned version for stability
+    const WEBLLM_VERSION = '0.2.82'; // pinned version — includes Qwen3 support
 
     let engine = null;
     let isLoading = false;
@@ -219,7 +219,7 @@
         }
 
         isLoading = true;
-        const statusLine = printLine('Loading model... (first time downloads ~500MB)', 'ghost-loading');
+        const statusLine = printLine('Loading model... (first time downloads ~300MB)', 'ghost-loading');
 
         try {
             const webllm = await import(`https://esm.run/@mlc-ai/web-llm@${WEBLLM_VERSION}`);

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -186,25 +186,6 @@
         const output = document.getElementById('ghost-output');
         output.innerHTML = '';
 
-        if (isMobileDevice()) {
-            printLine("┌──────────────────────────────────────┐", 'ghost-system');
-            printLine("│  ghost@dtizzal.com — digital ghost   │", 'ghost-system');
-            printLine("│                                       │", 'ghost-system');
-            printLine("│  The ghost requires WebGPU + GPU RAM │", 'ghost-system');
-            printLine("│  that most mobile devices lack.       │", 'ghost-system');
-            printLine("│  Visit on desktop Chrome 113+ to     │", 'ghost-system');
-            printLine("│  chat with the ghost.                 │", 'ghost-system');
-            printLine("└──────────────────────────────────────┘", 'ghost-system');
-            printLine('', 'ghost-system');
-            // Disable input on mobile
-            const input = document.getElementById('ghost-input');
-            if (input) {
-                input.disabled = true;
-                input.placeholder = 'desktop only — WebGPU required';
-            }
-            return;
-        }
-
         printLine("┌──────────────────────────────────────┐", 'ghost-system');
         printLine("│  ghost@dtizzal.com — digital ghost   │", 'ghost-system');
         printLine("│  Ask me about DT's blog, ideas,      │", 'ghost-system');
@@ -214,6 +195,13 @@
         printLine("│  Everything runs locally. No servers. │", 'ghost-system');
         printLine("└──────────────────────────────────────┘", 'ghost-system');
         printLine('', 'ghost-system');
+
+        if (isMobileDevice()) {
+            printLine("⚠ Mobile detected — memory is limited.", 'ghost-loading');
+            printLine("  Responses capped to avoid crashes.", 'ghost-loading');
+            printLine("  For best experience, use desktop.", 'ghost-loading');
+            printLine('', 'ghost-system');
+        }
     }
 
     // ─── WebLLM Engine ──────────────────────────────────────────
@@ -271,7 +259,6 @@
         const input = document.getElementById('ghost-input');
         const query = input.value.trim();
         if (!query || isGenerating) return;
-        if (isMobileDevice()) return;
 
         input.value = '';
 
@@ -290,8 +277,10 @@
         // Add to history
         chatHistory.push({ role: 'user', content: query });
 
-        // Trim history to keep context manageable
-        while (chatHistory.length > MAX_HISTORY * 2) {
+        // On mobile, keep less history to reduce memory pressure
+        const mobile = isMobileDevice();
+        const maxTurns = mobile ? 3 : MAX_HISTORY;
+        while (chatHistory.length > maxTurns * 2) {
             chatHistory.shift();
         }
 
@@ -313,7 +302,7 @@
             const asyncChunkGenerator = await engine.chat.completions.create({
                 messages: messages,
                 temperature: 0.7,
-                max_tokens: 512,
+                max_tokens: mobile ? 192 : 512,
                 stream: true,
             });
 
@@ -342,8 +331,24 @@
             // Add assistant response to history
             chatHistory.push({ role: 'assistant', content: fullResponse });
         } catch (err) {
-            responseLine.textContent = 'Error: ' + err.message;
+            if (spinnerLine.parentNode) {
+                spinnerLine.remove();
+                responseLine.style.display = '';
+            }
+            const msg = err.message || String(err);
+            responseLine.textContent = 'Error: ' + msg;
             responseLine.className = 'ghost-line ghost-error';
+
+            // On memory-related errors, try to recover by clearing history and resetting engine
+            if (mobile || /memory|oom|abort|lost|destroyed/i.test(msg)) {
+                chatHistory = [];
+                if (engine) {
+                    try { engine.unload?.(); } catch (_) { /* ignore */ }
+                    engine = null;
+                }
+                printLine('Memory pressure detected — context cleared.', 'ghost-error');
+                printLine('You can try again with a shorter question.', 'ghost-loading');
+            }
         }
 
         // Add blank line after response

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -4,11 +4,24 @@
 (function () {
     'use strict';
 
-    const MODEL_ID = 'Qwen3-0.6B-q4f16_1-MLC';
-    const MAX_HISTORY = 10; // max conversation turns to keep in context
     const WEBLLM_VERSION = '0.2.82'; // pinned version — includes Qwen3 support
 
+    // ─── Model Catalog ───────────────────────────────────────────
+
+    const MODELS = [
+        { id: 'SmolLM2-360M-Instruct-q4f16_1-MLC',   label: 'SmolLM2 360M',  brand: 'HuggingFace', vram: '~376MB',  size: '~200MB', mobile: true },
+        { id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC',    label: 'Llama 3.2 1B',  brand: 'Meta',        vram: '~879MB',  size: '~500MB', mobile: true },
+        { id: 'Qwen3-0.6B-q4f16_1-MLC',               label: 'Qwen3 0.6B',    brand: 'Alibaba',     vram: '~1.4GB',  size: '~300MB', mobile: true },
+        { id: 'gemma-2-2b-it-q4f16_1-MLC',            label: 'Gemma 2 2B',    brand: 'Google',      vram: '~1.9GB',  size: '~1.2GB', mobile: false },
+        { id: 'Qwen3-1.7B-q4f16_1-MLC',               label: 'Qwen3 1.7B',    brand: 'Alibaba',     vram: '~2.0GB',  size: '~900MB', mobile: false },
+    ];
+
+    const DEFAULT_MODEL_ID = 'Qwen3-0.6B-q4f16_1-MLC';
+    const MAX_HISTORY = 10;
+
+    let currentModelId = DEFAULT_MODEL_ID;
     let engine = null;
+    let webllmModule = null;
     let isLoading = false;
     let isGenerating = false;
     let chatHistory = [];
@@ -18,6 +31,15 @@
     function isMobileDevice() {
         return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
             || (window.innerWidth <= 768 && 'ontouchstart' in window);
+    }
+
+    function getModel(id) {
+        return MODELS.find(m => m.id === id);
+    }
+
+    function getAvailableModels() {
+        if (isMobileDevice()) return MODELS.filter(m => m.mobile);
+        return MODELS;
     }
 
     // ─── DOM Creation ───────────────────────────────────────────
@@ -40,7 +62,7 @@
                 <div id="ghost-output"></div>
                 <div id="ghost-input-row">
                     <span class="ghost-input-prompt">$&nbsp;</span>
-                    <input type="text" id="ghost-input" placeholder="ask the ghost something..." autocomplete="off" spellcheck="false" />
+                    <input type="text" id="ghost-input" placeholder="ask the ghost something... (type /model for options)" autocomplete="off" spellcheck="false" />
                 </div>
             </div>
         `;
@@ -53,7 +75,6 @@
 
     function bindEvents() {
         const bar = document.getElementById('ghost-bar');
-        const panel = document.getElementById('ghost-panel');
         const input = document.getElementById('ghost-input');
         const resizeHandle = document.getElementById('ghost-resize-handle');
 
@@ -193,6 +214,7 @@
         printLine("│                                       │", 'ghost-system');
         printLine("│  Powered by in-browser AI (WebLLM)   │", 'ghost-system');
         printLine("│  Everything runs locally. No servers. │", 'ghost-system');
+        printLine("│  Type /model to switch models.        │", 'ghost-system');
         printLine("└──────────────────────────────────────┘", 'ghost-system');
         printLine('', 'ghost-system');
 
@@ -202,6 +224,52 @@
             printLine("  For best experience, use desktop.", 'ghost-loading');
             printLine('', 'ghost-system');
         }
+    }
+
+    // ─── /model Command ─────────────────────────────────────────
+
+    function handleModelCommand(args) {
+        const available = getAvailableModels();
+
+        // /model with no args — list models
+        if (!args) {
+            printLine('Available models:', 'ghost-system');
+            printLine('', 'ghost-system');
+            available.forEach(function (m, i) {
+                const active = m.id === currentModelId ? ' ◀ active' : '';
+                printLine('  ' + (i + 1) + ') ' + m.label + ' (' + m.brand + ') — ' + m.vram + ' VRAM, ~' + m.size + ' download' + active, 'ghost-system');
+            });
+            printLine('', 'ghost-system');
+            printLine('Usage: /model <number>  e.g. /model 3', 'ghost-loading');
+            printLine('', 'ghost-system');
+            return;
+        }
+
+        // /model <number> — switch model
+        const idx = parseInt(args, 10);
+        if (isNaN(idx) || idx < 1 || idx > available.length) {
+            printLine('Invalid model number. Type /model to see the list.', 'ghost-error');
+            return;
+        }
+
+        const selected = available[idx - 1];
+        if (selected.id === currentModelId && engine) {
+            printLine('Already using ' + selected.label + '.', 'ghost-system');
+            return;
+        }
+
+        // Unload current engine
+        if (engine) {
+            printLine('Unloading ' + (getModel(currentModelId)?.label || currentModelId) + '...', 'ghost-loading');
+            try { engine.unload?.(); } catch (_) { /* ignore */ }
+            engine = null;
+        }
+
+        currentModelId = selected.id;
+        chatHistory = [];
+        printLine('Switched to ' + selected.label + ' (' + selected.brand + ').', 'ghost-system');
+        printLine('Model will load on your next message.', 'ghost-loading');
+        printLine('', 'ghost-system');
     }
 
     // ─── WebLLM Engine ──────────────────────────────────────────
@@ -219,12 +287,17 @@
         }
 
         isLoading = true;
-        const statusLine = printLine('Loading model... (first time downloads ~300MB)', 'ghost-loading');
+        const model = getModel(currentModelId);
+        const label = model ? model.label : currentModelId;
+        const dlSize = model ? model.size : '?';
+        const statusLine = printLine('Loading ' + label + '... (first time downloads ' + dlSize + ')', 'ghost-loading');
 
         try {
-            const webllm = await import(`https://esm.run/@mlc-ai/web-llm@${WEBLLM_VERSION}`);
+            if (!webllmModule) {
+                webllmModule = await import(`https://esm.run/@mlc-ai/web-llm@${WEBLLM_VERSION}`);
+            }
 
-            engine = await webllm.CreateMLCEngine(MODEL_ID, {
+            engine = await webllmModule.CreateMLCEngine(currentModelId, {
                 initProgressCallback: (progress) => {
                     if (progress.text) {
                         statusLine.textContent = progress.text;
@@ -233,14 +306,14 @@
                 }
             });
 
-            statusLine.textContent = 'Model loaded. Ready.';
+            statusLine.textContent = label + ' loaded. Ready.';
             statusLine.className = 'ghost-line ghost-system';
             printLine('', 'ghost-system');
             isLoading = false;
             return true;
         } catch (err) {
             isLoading = false;
-            statusLine.textContent = 'Failed to load model.';
+            statusLine.textContent = 'Failed to load ' + label + '.';
             statusLine.className = 'ghost-line ghost-error';
             printLine('Error: ' + err.message, 'ghost-error');
             printLine('', 'ghost-system');
@@ -261,6 +334,35 @@
         if (!query || isGenerating) return;
 
         input.value = '';
+
+        // Check for /model command
+        if (query.startsWith('/model')) {
+            printHTML('<span class="ghost-prompt-echo">$ </span>' + escapeHTML(query), 'ghost-user-line');
+            const args = query.slice(6).trim() || null;
+            handleModelCommand(args);
+            return;
+        }
+
+        // Check for /help command
+        if (query === '/help') {
+            printHTML('<span class="ghost-prompt-echo">$ </span>' + escapeHTML(query), 'ghost-user-line');
+            printLine('Commands:', 'ghost-system');
+            printLine('  /model         — list available models', 'ghost-system');
+            printLine('  /model <n>     — switch to model #n', 'ghost-system');
+            printLine('  /clear         — clear chat history', 'ghost-system');
+            printLine('  /help          — show this help', 'ghost-system');
+            printLine('', 'ghost-system');
+            return;
+        }
+
+        // Check for /clear command
+        if (query === '/clear') {
+            printHTML('<span class="ghost-prompt-echo">$ </span>' + escapeHTML(query), 'ghost-user-line');
+            chatHistory = [];
+            printLine('Chat history cleared.', 'ghost-system');
+            printLine('', 'ghost-system');
+            return;
+        }
 
         // Echo user input
         printHTML('<span class="ghost-prompt-echo">$ </span>' + escapeHTML(query), 'ghost-user-line');

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -6,6 +6,7 @@
 
     const MODEL_ID = 'Llama-3.2-1B-Instruct-q4f16_1-MLC';
     const MAX_HISTORY = 10; // max conversation turns to keep in context
+    const WEBLLM_VERSION = '0.2.78'; // pinned version for stability
 
     let engine = null;
     let isLoading = false;
@@ -13,6 +14,11 @@
     let chatHistory = [];
     let isExpanded = false;
     let resizeState = null;
+
+    function isMobileDevice() {
+        return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
+            || (window.innerWidth <= 768 && 'ontouchstart' in window);
+    }
 
     // ─── DOM Creation ───────────────────────────────────────────
 
@@ -179,6 +185,26 @@
     function printWelcome() {
         const output = document.getElementById('ghost-output');
         output.innerHTML = '';
+
+        if (isMobileDevice()) {
+            printLine("┌──────────────────────────────────────┐", 'ghost-system');
+            printLine("│  ghost@dtizzal.com — digital ghost   │", 'ghost-system');
+            printLine("│                                       │", 'ghost-system');
+            printLine("│  The ghost requires WebGPU + GPU RAM │", 'ghost-system');
+            printLine("│  that most mobile devices lack.       │", 'ghost-system');
+            printLine("│  Visit on desktop Chrome 113+ to     │", 'ghost-system');
+            printLine("│  chat with the ghost.                 │", 'ghost-system');
+            printLine("└──────────────────────────────────────┘", 'ghost-system');
+            printLine('', 'ghost-system');
+            // Disable input on mobile
+            const input = document.getElementById('ghost-input');
+            if (input) {
+                input.disabled = true;
+                input.placeholder = 'desktop only — WebGPU required';
+            }
+            return;
+        }
+
         printLine("┌──────────────────────────────────────┐", 'ghost-system');
         printLine("│  ghost@dtizzal.com — digital ghost   │", 'ghost-system');
         printLine("│  Ask me about DT's blog, ideas,      │", 'ghost-system');
@@ -208,7 +234,7 @@
         const statusLine = printLine('Loading model... (first time downloads ~500MB)', 'ghost-loading');
 
         try {
-            const webllm = await import('https://esm.run/@mlc-ai/web-llm');
+            const webllm = await import(`https://esm.run/@mlc-ai/web-llm@${WEBLLM_VERSION}`);
 
             engine = await webllm.CreateMLCEngine(MODEL_ID, {
                 initProgressCallback: (progress) => {
@@ -245,6 +271,7 @@
         const input = document.getElementById('ghost-input');
         const query = input.value.trim();
         if (!query || isGenerating) return;
+        if (isMobileDevice()) return;
 
         input.value = '';
 
@@ -274,8 +301,12 @@
             ...chatHistory
         ];
 
-        // Create response line for streaming
+        // Show spinner while waiting for first token
+        const spinnerLine = printHTML('<span class="ghost-spinner">thinking...</span>', '');
+
+        // Create response line for streaming (hidden until first token)
         const responseLine = printLine('', 'ghost-response');
+        responseLine.style.display = 'none';
         let fullResponse = '';
 
         try {
@@ -288,9 +319,19 @@
 
             for await (const chunk of asyncChunkGenerator) {
                 const delta = chunk.choices[0]?.delta?.content || '';
+                if (delta && spinnerLine.parentNode) {
+                    spinnerLine.remove();
+                    responseLine.style.display = '';
+                }
                 fullResponse += delta;
                 responseLine.textContent = fullResponse;
                 scrollOutput();
+            }
+
+            // Clean up spinner if no tokens were generated
+            if (spinnerLine.parentNode) {
+                spinnerLine.remove();
+                responseLine.style.display = '';
             }
 
             if (!fullResponse.trim()) {


### PR DESCRIPTION
## Summary

- Adds a terminal-styled chat widget ("digital ghost") to every page, powered by **WebLLM** running entirely client-side via WebGPU — no servers, no API keys, no costs
- Widget appears as a compact muted `ghost@dtizzal.com ~ ask-dt` prompt bar at the bottom of every page; clicking expands into a resizable dark transparent terminal overlay
- LLM is pre-loaded with a system prompt containing DT's blog content index (all 15 posts summarized), about page info, writing style, and personality traits so it can answer as DT's "digital ghost"
- Supports dark/light mode, mobile responsive, keyboard shortcuts (Escape to close), drag-to-resize

### Multi-Model Selector

Type `/model` in the chat to list and switch between models from different brands:

| # | Model | Brand | VRAM | Download |
|---|---|---|---|---|
| 1 | SmolLM2 360M | HuggingFace | ~376MB | ~200MB |
| 2 | Llama 3.2 1B | Meta | ~879MB | ~500MB |
| 3 | **Qwen3 0.6B** (default) | Alibaba | ~1.4GB | ~300MB |
| 4 | Gemma 2 2B | Google | ~1.9GB | ~1.2GB |
| 5 | Qwen3 1.7B | Alibaba | ~2.0GB | ~900MB |

- `/model` — list available models with active indicator
- `/model <n>` — switch model (unloads current, lazy-loads on next message)
- `/clear` — clear conversation history
- `/help` — show all commands

### Mobile Support
- Mobile users only see mobile-safe models (#1-3, under ~1.5GB VRAM)
- Responses capped at 192 tokens, history limited to 3 turns
- OOM error recovery: auto-unloads engine and clears history on memory errors

### Styling
- Dark transparent overlays (`rgba(10,10,10,0.6)`) that let page content bleed through
- Muted white text tones throughout
- Loading spinner while LLM generates responses
- WebLLM pinned to v0.2.82

### Files

| File | Purpose |
|------|---------|
| `js/ghost-context.js` | System prompt with blog content index and personality |
| `js/ghost-chat.js` | Terminal UI, model selector, WebLLM integration |
| `css/style.css` | Dark transparent overlay styles, spinner, dark/light mode |
| All `*.html` files | Added ghost chat script tags |

## Test plan

- [ ] Open any page in Chrome 113+ and verify the terminal bar appears at the bottom
- [ ] Click the bar to expand; send a message; verify spinner → model download → streaming response
- [ ] Type `/model` and verify the model list displays with active indicator
- [ ] Type `/model 2` and verify it switches to Llama 3.2 1B, then send a message
- [ ] Type `/clear` and verify history is cleared
- [ ] Test on iPhone Safari — should show mobile warning, only 3 models listed, responses capped
- [ ] Test resize by dragging the handle at the top of the panel
- [ ] Test Escape key closes the panel
- [ ] Toggle light mode and verify chat widget adapts
- [ ] Open in Firefox and verify graceful "WebGPU not available" message

https://claude.ai/code/session_01Nw3czRtfTkH1bwrZsQEa6P