### PR TITLE
Add in-browser AI chatbot with blog search

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1060,6 +1060,11 @@ body.light-mode #ghost-input::placeholder { color: rgba(0, 0, 0, 0.2); }
     line-height: 1.6;
     white-space: pre-wrap;
     word-wrap: break-word;
+    transition: opacity 0.5s ease;
+}
+
+.ghost-tool-done {
+    opacity: 0;
 }
 
 .ghost-tool-header {

--- a/js/ghost-chat.js
+++ b/js/ghost-chat.js
@@ -255,6 +255,19 @@
         block.innerHTML = lines.join('\n');
         output.appendChild(block);
         scrollOutput();
+        return block;
+    }
+
+    function dismissToolBlock(block) {
+        if (!block || !block.parentNode) return;
+        // Update footer to show completion, then fade out
+        var footer = block.querySelector('.ghost-tool-footer');
+        if (footer) footer.textContent = '\u2514\u2500 done';
+        block.classList.add('ghost-tool-done');
+        setTimeout(function () {
+            if (block.parentNode) block.remove();
+            scrollOutput();
+        }, 600);
     }
 
     // ─── Link Rendering ─────────────────────────────────────────
@@ -461,7 +474,7 @@
                 if (spinnerLine && spinnerLine.parentNode) {
                     spinnerLine.remove();
                 }
-                printToolCall('search_blog', searchQuery, results);
+                var toolBlock = printToolCall('search_blog', searchQuery, results);
 
                 // Add tool result to messages
                 var contextStr = window.ghostSearch ? window.ghostSearch.format(results) : '';
@@ -473,7 +486,7 @@
             }
         }
 
-        return { messages: messages, results: allResults };
+        return { messages: messages, results: allResults, toolBlock: toolBlock };
     }
 
     // ─── Safe Streaming Helper ─────────────────────────────────
@@ -612,7 +625,8 @@
                 var toolResult = await handleToolCallResponse(firstCompletion, messages, spinnerLine);
 
                 if (toolResult) {
-                    // Tool was called — now stream the final response
+                    // Tool was called — dismiss tool block and stream the final response
+                    dismissToolBlock(toolResult.toolBlock);
                     if (spinnerLine.parentNode) {
                         spinnerLine.remove();
                     }
@@ -640,13 +654,14 @@
             } else {
                 // Path B: Auto-search fallback — search before every query
                 var searchResults = await performSearch(query, topK);
+                var toolBlock = null;
 
                 if (searchResults.length > 0) {
                     // Show search visualization
                     if (spinnerLine.parentNode) {
                         spinnerLine.remove();
                     }
-                    printToolCall('search_blog', query, searchResults);
+                    toolBlock = printToolCall('search_blog', query, searchResults);
                 }
 
                 var searchContext = window.ghostSearch
@@ -660,6 +675,9 @@
                     { role: 'system', content: systemPrompt },
                     ...chatHistory
                 ];
+
+                // Dismiss tool block now that context is injected
+                dismissToolBlock(toolBlock);
 
                 // Update spinner if still visible
                 if (spinnerLine.parentNode) {


### PR DESCRIPTION
## Summary

- **In-browser AI chatbot ("digital ghost")** powered by WebLLM — runs entirely client-side via WebGPU, no servers or API keys
- **Client-side RAG** using MiniSearch to search blog posts and resume, injecting relevant context into the LLM prompt
- **Multi-model selector** (`/model` command) with 5 models across HuggingFace, Meta, Alibaba, and Google
- **Mobile-optimized**: defaults to SmolLM2 360M (~376MB VRAM) on mobile vs Qwen3 0.6B on desktop, with reduced token limits and history caps
- **Terminal-style UI** with collapsible panel, resize handle, streaming token display, and dark/light mode support
- **Tool call visualization** that fades out after context injection completes
- **Darker terminal overlay** — near-black (`rgba(5,5,5,0.88-0.92)`) instead of translucent grey
- **Mobile crash fix** for "Object has already been disposed" — safe streaming helper catches mid-stream GPU disposal gracefully

## Test plan

- [ ] Desktop: open site, expand ghost chat, send a message — model should download and respond with blog context
- [ ] Desktop: verify `/model` lists all 5 models, switching works
- [ ] Desktop: verify terminal overlay is dark/near-black
- [ ] Mobile: verify SmolLM2 360M loads by default (not Qwen3)
- [ ] Mobile: send multiple messages — no "Object disposed" crash
- [ ] Mobile: tool call block fades out after context injection
- [ ] Verify search results show relevant blog posts for domain-specific queries
- [ ] Verify light mode styling works correctly

https://claude.ai/code/session_01Nw3czRtfTkH1bwrZsQEa6P